### PR TITLE
Updates config tag for artisan vendor:publish

### DIFF
--- a/src/FeatureFlagsServiceProvider.php
+++ b/src/FeatureFlagsServiceProvider.php
@@ -24,7 +24,7 @@ class FeatureFlagsServiceProvider extends ServiceProvider
     {
         $this->publishes([
             __DIR__ . '/../config/feature-flags.php' => config_path('feature-flags.php')
-        ], 'config');
+        ], 'feature-flags-config');
 
 
         Blade::directive('feature', function ($feature) {


### PR DESCRIPTION
Currently if you run `php artisan vendor:publish` the tag for publishing the config is just `config`. This could get confusing, so renamed it to `feature-flags-config`