### PR TITLE
Add tests for blade directives And fix `groupfeature` directive

### DIFF
--- a/src/Concerns/HasFeatures.php
+++ b/src/Concerns/HasFeatures.php
@@ -150,7 +150,9 @@ trait HasFeatures
 
     public function groupHasFeature(string $featureName): bool
     {
-        return $this->groups->features->contains('name', $featureName);
+        return $this->hasFeatureThroughGroup(
+            feature: $featureName,
+        );
     }
 
     protected function featureExists(string $featureName): bool

--- a/tests/BladeDirectivesTest.php
+++ b/tests/BladeDirectivesTest.php
@@ -61,6 +61,34 @@ class BladeDirectivesTest extends TestCase
     /**
      * @test
      */
+    public function it_shows_feature_to_user_when_feature_group_has_feature()
+    {
+        $user = User::create([
+            'name' => 'test user',
+            'email' => 'test@user.com',
+            'password' => Hash::make('password')
+        ]);
+
+        $feature = Feature::create([
+            'name' => 'test'
+        ]);
+
+        $group = FeatureGroup::create([
+            'name' => 'Test Group',
+        ]);
+
+        $group->addFeature($feature);
+
+        $user->joinGroup($group->name);
+
+        $view = $this->actingAs($user)->blade("@groupfeature('test') active feature @endgroupfeature");
+
+        $view->assertSee('active feature');
+    }
+
+    /**
+     * @test
+     */
     public function it_hides_feature_to_user_that_dont_have_feature()
     {
         $user = User::create([
@@ -86,6 +114,28 @@ class BladeDirectivesTest extends TestCase
         ]);
 
         $view = $this->actingAs($user)->blade("@featuregroup('test group') active feature @endfeaturegroup");
+
+        $view->assertSee('');
+    }
+
+    /**
+     * @test
+     */
+    public function it_hides_feature_to_user_when_feature_group_dont_have_feature()
+    {
+        $user = User::create([
+            'name' => 'test user',
+            'email' => 'test@user.com',
+            'password' => Hash::make('password')
+        ]);
+
+        $group = FeatureGroup::create([
+            'name' => 'Test Group',
+        ]);
+
+        $user->joinGroup($group->name);
+
+        $view = $this->actingAs($user)->blade("@groupfeature('test') active feature @endgroupfeature");
 
         $view->assertSee('');
     }

--- a/tests/BladeDirectivesTest.php
+++ b/tests/BladeDirectivesTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustSteveKing\Laravel\FeatureFlags\Tests;
+
+use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+use JustSteveKing\Laravel\FeatureFlags\Models\FeatureGroup;
+use JustSteveKing\Laravel\FeatureFlags\Tests\Stubs\User;
+use JustSteveKing\Laravel\FeatureFlags\Models\Feature;
+use Illuminate\Support\Facades\Hash;
+
+class BladeDirectivesTest extends TestCase
+{
+    use InteractsWithViews;
+
+    /**
+     * @test
+     */
+    public function it_shows_feature_to_user_that_have_feature()
+    {
+        $user = User::create([
+            'name' => 'test user',
+            'email' => 'test@user.com',
+            'password' => Hash::make('password')
+        ]);
+
+        $feature = Feature::create([
+            'name' => 'test'
+        ]);
+
+        $user->giveFeature($feature->name);
+
+        $view = $this->actingAs($user)->blade("@feature('test') active feature @endfeature");
+
+        $view->assertSee('active feature');
+    }
+
+    /**
+     * @test
+     */
+    public function it_shows_feature_to_user_in_feature_group()
+    {
+        $user = User::create([
+            'name' => 'test user',
+            'email' => 'test@user.com',
+            'password' => Hash::make('password')
+        ]);
+
+        $group = FeatureGroup::create([
+            'name' => 'Test Group',
+        ]);
+
+        $user->joinGroup($group->name);
+
+        $view = $this->actingAs($user)->blade("@featuregroup('test group') active feature @endfeaturegroup");
+
+        $view->assertSee('active feature');
+    }
+
+    /**
+     * @test
+     */
+    public function it_hides_feature_to_user_that_dont_have_feature()
+    {
+        $user = User::create([
+            'name' => 'test user',
+            'email' => 'test@user.com',
+            'password' => Hash::make('password')
+        ]);
+
+        $view = $this->actingAs($user)->blade("@feature('test') active feature @endfeature");
+
+        $view->assertSee('');
+    }
+
+    /**
+     * @test
+     */
+    public function it_hides_feature_to_user_not_in_feature_group()
+    {
+        $user = User::create([
+            'name' => 'test user',
+            'email' => 'test@user.com',
+            'password' => Hash::make('password')
+        ]);
+
+        $view = $this->actingAs($user)->blade("@featuregroup('test group') active feature @endfeaturegroup");
+
+        $view->assertSee('');
+    }
+}


### PR DESCRIPTION
This PR adds tests for the blade directives. Tried testing `@groupfeature` directive but it keeps failing, stating "Exception: Property [features] does not exist on this collection instance", referring to the `groupHasFeature` method. Might be something to look into later. https://github.com/JustSteveKing/laravel-feature-flags/blob/ece292c6550672639cda3990576b9936f2282aa0/src/Concerns/HasFeatures.php#L151-L154

The added test will fail due to the die-dump in `HasFeatures` trait, but here's a screenshot of the test suite passing. 😀

![Screen Shot 2021-06-17 at 12 31 18 PM](https://user-images.githubusercontent.com/2221746/122381087-d3afe300-cf68-11eb-8925-648c81ad3d62.png)
