### PR TITLE
Add tests for `artisan` commands

### DIFF
--- a/tests/FeatureArtisanTest.php
+++ b/tests/FeatureArtisanTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace JustSteveKing\Laravel\FeatureFlags\Tests;
+
+use Illuminate\Foundation\Testing\Concerns\InteractsWithConsole;
+use JustSteveKing\Laravel\FeatureFlags\Models\Feature;
+
+class FeatureArtisanTest extends TestCase
+{
+    use InteractsWithConsole;
+
+    /**
+     * @test
+     */
+    public function it_can_add_a_new_feature()
+    {
+        $this->artisan('feature-flags:add-feature')
+            ->expectsQuestion('Feature Name', 'test feature')
+            ->expectsQuestion('Feature Description', 'A description')
+            ->expectsChoice('Is the feature active', 'yes', ['yes', 'no'])
+            ->expectsOutput("Created 'test feature' feature")
+            ->assertExitCode(0);
+
+        $this->assertCount(1, Feature::all());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_ask_again_if_feature_already_exists()
+    {
+        Feature::create([
+            'name' => 'test feature',
+        ]);
+
+        $this->artisan('feature-flags:add-feature')
+            ->expectsQuestion('Feature Name', 'test feature')
+            ->expectsQuestion('Feature Name', 'another feature')
+            ->expectsQuestion('Feature Description', 'A description')
+            ->expectsChoice('Is the feature active', 'yes', ['yes', 'no'])
+            ->expectsOutput("Created 'another feature' feature")
+            ->assertExitCode(0);
+
+        $this->assertCount(2, Feature::all());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_activate_a_inactive_feature()
+    {
+        Feature::create([
+            'name' => 'test feature',
+            'active' => false,
+        ]);
+
+        $this->artisan('feature-flags:activate-feature')
+            ->expectsQuestion('Feature name to activate', 'test feature')
+            ->expectsOutput("Feature 'test feature' has been successfully activated")
+            ->assertExitCode(0);
+
+        $this->assertTrue(Feature::first()->active);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_not_activate_a_active_feature()
+    {
+        Feature::create([
+            'name' => 'test feature',
+            'active' => true,
+        ]);
+
+        $this->artisan('feature-flags:activate-feature')
+            ->expectsQuestion('Feature name to activate', 'test feature')
+            ->expectsOutput("Feature 'test feature' is already active.")
+            ->assertExitCode(0);
+
+        $this->assertTrue(Feature::first()->active);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_ask_again_if_activating_feature_was_not_found()
+    {
+        Feature::create([
+            'name' => 'test feature',
+            'active' => false,
+        ]);
+
+        $this->artisan('feature-flags:activate-feature')
+            ->expectsQuestion('Feature name to activate', 'not found')
+            ->expectsQuestion('Feature name to activate', 'test feature')
+            ->expectsOutput("Feature 'test feature' has been successfully activated")
+            ->assertExitCode(0);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_deactivate_a_active_feature()
+    {
+        Feature::create([
+            'name' => 'test feature',
+            'active' => true,
+        ]);
+
+        $this->artisan('feature-flags:deactivate-feature')
+            ->expectsQuestion('Feature name to deactivate', 'test feature')
+            ->expectsOutput("Feature 'test feature' has been successfully deactivated")
+            ->assertExitCode(0);
+
+        $this->assertFalse(Feature::first()->active);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_not_deactivate_a_inactive_feature()
+    {
+        Feature::create([
+            'name' => 'test feature',
+            'active' => false,
+        ]);
+
+        $this->artisan('feature-flags:deactivate-feature')
+            ->expectsQuestion('Feature name to deactivate', 'test feature')
+            ->expectsOutput("Feature 'test feature' is already inactive.")
+            ->assertExitCode(0);
+
+        $this->assertFalse(Feature::first()->active);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_ask_again_if_deactivating_feature_was_not_found()
+    {
+        Feature::create([
+            'name' => 'test feature',
+            'active' => true,
+        ]);
+
+        $this->artisan('feature-flags:deactivate-feature')
+            ->expectsQuestion('Feature name to deactivate', 'not found')
+            ->expectsQuestion('Feature name to deactivate', 'test feature')
+            ->expectsOutput("Feature 'test feature' has been successfully deactivated")
+            ->assertExitCode(0);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_display_a_table_of_empty_features()
+    {
+        $this->artisan('feature-flags:view-features')
+            ->expectsTable(['Name', 'Description', 'Active'], []);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_display_a_table_of_all_features()
+    {
+        Feature::create([
+            'name' => 'first feature',
+        ]);
+
+        Feature::create([
+            'name' => 'second feature',
+            'description' => 'A description'
+        ]);
+
+        Feature::create([
+            'name' => 'third feature',
+            'active' => false,
+        ]);
+
+        $expected_rows = Feature::all(['name', 'description', 'active'])->toArray();
+
+        $this->artisan('feature-flags:view-features')
+            ->expectsTable(['Name', 'Description', 'Active'], $expected_rows);
+    }
+}

--- a/tests/FeatureGroupArtisanTest.php
+++ b/tests/FeatureGroupArtisanTest.php
@@ -1,0 +1,335 @@
+<?php
+
+namespace JustSteveKing\Laravel\FeatureFlags\Tests;
+
+use Illuminate\Foundation\Testing\Concerns\InteractsWithConsole;
+use JustSteveKing\Laravel\FeatureFlags\Models\Feature;
+use JustSteveKing\Laravel\FeatureFlags\Models\FeatureGroup;
+
+class FeatureGroupArtisanTest extends TestCase
+{
+    use InteractsWithConsole;
+
+    /**
+     * @test
+    */
+    public function it_can_create_a_new_feature_group()
+    {
+        $this->artisan('feature-flags:add-feature-group')
+            ->expectsQuestion('Group Name', 'test group')
+            ->expectsQuestion('Group Description', 'A group description')
+            ->expectsChoice('Is the group active', 'yes', ['no', 'yes'])
+            ->expectsOutput("Created 'test group' group")
+            ->assertExitCode(0);
+    }
+    /**
+     * @test
+     */
+    public function it_can_ask_again_if_feature_group_already_exists()
+    {
+        FeatureGroup::create([
+            'name' => 'test group',
+        ]);
+
+        $this->artisan('feature-flags:add-feature-group')
+            ->expectsQuestion('Group Name', 'test group')
+            ->expectsQuestion('Group Name', 'another group')
+            ->expectsQuestion('Group Description', 'A group description')
+            ->expectsChoice('Is the group active', 'yes', ['no', 'yes'])
+            ->expectsOutput("Created 'another group' group")
+            ->assertExitCode(0);
+
+        $this->assertCount(2, FeatureGroup::all());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_activate_a_inactive_feature_group()
+    {
+        FeatureGroup::create([
+            'name' => 'test group',
+            'active' => false,
+        ]);
+
+        $this->artisan('feature-flags:activate-feature-group')
+            ->expectsQuestion('Group name to activate', 'test group')
+            ->expectsOutput("Group 'test group' has been successfully activated")
+            ->assertExitCode(0);
+
+        $this->assertTrue(FeatureGroup::first()->active);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_not_activate_a_active_feature_group()
+    {
+        FeatureGroup::create([
+            'name' => 'test group',
+            'active' => true,
+        ]);
+
+        $this->artisan('feature-flags:activate-feature-group')
+            ->expectsQuestion('Group name to activate', 'test group')
+            ->expectsOutput("Group 'test group' is already active.")
+            ->assertExitCode(0);
+
+        $this->assertTrue(FeatureGroup::first()->active);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_ask_again_if_activating_feature_group_was_not_found()
+    {
+        FeatureGroup::create([
+            'name' => 'test group',
+            'active' => false,
+        ]);
+
+        $this->artisan('feature-flags:activate-feature-group')
+            ->expectsQuestion('Group name to activate', 'not found')
+            ->expectsQuestion('Group name to activate', 'test group')
+            ->expectsOutput("Group 'test group' has been successfully activated")
+            ->assertExitCode(0);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_deactivate_a_active_feature_group()
+    {
+        FeatureGroup::create([
+            'name' => 'test group',
+            'active' => true,
+        ]);
+
+        $this->artisan('feature-flags:deactivate-feature-group')
+            ->expectsQuestion('Group name to deactivate', 'test group')
+            ->expectsOutput("Group 'test group' has been successfully deactivated")
+            ->assertExitCode(0);
+
+        $this->assertFalse(FeatureGroup::first()->active);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_not_deactivate_a_inactive_feature_group()
+    {
+        FeatureGroup::create([
+            'name' => 'test group',
+            'active' => false,
+        ]);
+
+        $this->artisan('feature-flags:deactivate-feature-group')
+            ->expectsQuestion('Group name to deactivate', 'test group')
+            ->expectsOutput("Group 'test group' is already inactive.")
+            ->assertExitCode(0);
+
+        $this->assertFalse(FeatureGroup::first()->active);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_ask_again_if_deactivating_feature_group_was_not_found()
+    {
+        FeatureGroup::create([
+            'name' => 'test group',
+            'active' => true,
+        ]);
+
+        $this->artisan('feature-flags:deactivate-feature-group')
+            ->expectsQuestion('Group name to deactivate', 'not found')
+            ->expectsQuestion('Group name to deactivate', 'test group')
+            ->expectsOutput("Group 'test group' has been successfully deactivated")
+            ->assertExitCode(0);
+
+        $this->assertFalse(FeatureGroup::first()->active);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_display_a_table_of_empty_feature_groups()
+    {
+        $this->artisan('feature-flags:view-feature-groups')
+            ->expectsTable(['Name', 'Description', 'Active'], []);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_display_a_table_of_all_feature_groups()
+    {
+        FeatureGroup::create([
+            'name' => 'test group',
+        ]);
+
+        FeatureGroup::create([
+            'name' => 'test group',
+            'active' => 'false',
+        ]);
+
+        FeatureGroup::create([
+            'name' => 'test group',
+            'description' => 'A group description',
+        ]);
+
+        $expected_rows = FeatureGroup::all(['name', 'description', 'active'])->toArray();
+
+        $this->artisan('feature-flags:view-feature-groups')
+            ->expectsTable(['Name', 'Description', 'Active'], $expected_rows);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_add_a_feature_to_a_feature_group()
+    {
+        FeatureGroup::create([
+            'name' => 'test group',
+        ]);
+
+        Feature::create([
+            'name' => 'test feature',
+        ]);
+
+        $this->artisan('feature-flags:add-feature-to-group')
+            ->expectsQuestion('Feature Name', 'test feature')
+            ->expectsQuestion('Group Name', 'test group')
+            ->expectsOutput("Added feature 'test feature' to group 'test group'")
+            ->assertExitCode(0);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_ask_for_feature_again_if_feature_to_add_didnt_exist()
+    {
+        FeatureGroup::create([
+            'name' => 'test group',
+        ]);
+
+        Feature::create([
+            'name' => 'test feature',
+        ]);
+
+        $this->artisan('feature-flags:add-feature-to-group')
+            ->expectsQuestion('Feature Name', 'another feature')
+            ->expectsQuestion('Feature Name', 'test feature')
+            ->expectsQuestion('Group Name', 'test group')
+            ->expectsOutput("Added feature 'test feature' to group 'test group'")
+            ->assertExitCode(0);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_ask_for_feature_group_if_group_to_add_feature_didnt_exist()
+    {
+        FeatureGroup::create([
+            'name' => 'test group',
+        ]);
+
+        Feature::create([
+            'name' => 'test feature',
+        ]);
+
+        $this->artisan('feature-flags:add-feature-to-group')
+            ->expectsQuestion('Feature Name', 'test feature')
+            ->expectsQuestion('Group Name', 'another group')
+            ->expectsQuestion('Group Name', 'test group')
+            ->expectsOutput("Added feature 'test feature' to group 'test group'")
+            ->assertExitCode(0);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_alert_if_feature_is_already_assigned_to_feature_group()
+    {
+        $group = FeatureGroup::create([
+            'name' => 'test group',
+        ]);
+
+        $feature = Feature::create([
+            'name' => 'test feature',
+        ]);
+
+        $group->addFeature($feature);
+
+        $this->artisan('feature-flags:add-feature-to-group')
+            ->expectsQuestion('Feature Name', 'test feature')
+            ->expectsQuestion('Group Name', 'test group')
+            ->expectsOutput('*     This feature is already assigned to this group     *')
+            ->assertExitCode(1);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_display_an_empty_table_of_feature_group_with_features()
+    {
+        $this->artisan('feature-flags:view-groups-with-features')
+            ->expectsTable(['Group', 'Features'], []);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_display_a_table_with_feature_group_with_not_features()
+    {
+        FeatureGroup::create([
+            'name' => 'test group',
+        ]);
+
+        $this->artisan('feature-flags:view-groups-with-features')
+            ->expectsTable(['Group', 'Features'], [['test group'], []]);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_display_a_table_with_feature_group_with_one_feature()
+    {
+        $group = FeatureGroup::create([
+            'name' => 'test group',
+        ]);
+
+        $feature = Feature::create([
+            'name' => 'test feature',
+        ]);
+
+        $group->addFeature($feature);
+
+        $this->artisan('feature-flags:view-groups-with-features')
+            ->expectsTable(['Group', 'Features'], [['test group', 'test feature']]);
+    }
+
+    /**
+     * @test
+    */
+    public function it_can_display_a_table_with_feature_group_with_nth_features()
+    {
+        $group = FeatureGroup::create([
+            'name' => 'test group',
+        ]);
+
+        $feature = Feature::create([
+            'name' => 'test feature',
+        ]);
+
+        $featureTwo = Feature::create([
+            'name' => 'another feature',
+        ]);
+
+        $group->addFeature($feature);
+        $group->addFeature($featureTwo);
+
+        $this->artisan('feature-flags:view-groups-with-features')
+            ->expectsTable(['Group', 'Features'], [['test group', 'test feature, another feature']]);
+    }
+}


### PR DESCRIPTION
As I was testing PHPStorm tonight figured I'd test it out by adding tests for the artisan commands. 🤷‍♂️ 
This PR includes 28 new tests for full test coverage of the artisan commands, all of them passing.

So now you don't have to do all this work yourself later down the line. 😀

<details>
<summary>Screenshots of test suite inc. in PR.</summary>

![Screen Shot 2021-06-19 at 5 12 04 AM](https://user-images.githubusercontent.com/2221746/122629485-a9bc0500-d0bd-11eb-8dae-e7b77de790cc.png)
</details>

<details>
<summary>Screenshots of test coverage inc. in PR.</summary>

![Screen Shot 2021-06-19 at 5 08 51 AM](https://user-images.githubusercontent.com/2221746/122629488-ad4f8c00-d0bd-11eb-8de1-9e05ee4e7230.png)
</details>
