### PR TITLE
Fix middleware and Add tests for middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,9 @@
     "require-dev": {
         "nunomaduro/collision": "^5.3",
         "orchestra/testbench": "^6.15",
-        "phpunit/phpunit": "^9.3",
         "pestphp/pest": "^1.9",
+        "pestphp/pest-plugin-laravel": "^1.2",
+        "phpunit/phpunit": "^9.3",
         "vimeo/psalm": "^4.4"
     },
     "autoload": {

--- a/src/Http/Middleware/API/FeatureMiddleware.php
+++ b/src/Http/Middleware/API/FeatureMiddleware.php
@@ -12,11 +12,11 @@ class FeatureMiddleware
     public function handle(Request $request, Closure $next, string ...$features): mixed
     {
         foreach ($features as $feature) {
-            $feature = str_replace($feature, '-', ' ');
-        }
+            $feature = str_replace('-', ' ', $feature);
 
-        if (! $request->user()->hasFeature($features)) {
-            return abort(config('feature-flag.middleware.status_code'));
+            if (! $request->user()->hasFeature($feature)) {
+                return abort(config('feature-flags.middleware.status_code'));
+            }
         }
 
         return $next($request);

--- a/src/Http/Middleware/API/GroupMiddleware.php
+++ b/src/Http/Middleware/API/GroupMiddleware.php
@@ -14,11 +14,11 @@ class GroupMiddleware
         foreach ($groups as $group) {
             $group = str_replace('-', ' ', $group);
 
-            if (! $request->user()->inGroup($group)) {
-                return abort(config('feature-flags.middleware.status_code'));
+            if ($request->user()->inGroup($group)) {
+                return $next($request);
             }
-
-            return $next($request);
         }
+
+        return abort(config('feature-flags.middleware.status_code'));
     }
 }

--- a/src/Http/Middleware/API/GroupMiddleware.php
+++ b/src/Http/Middleware/API/GroupMiddleware.php
@@ -12,13 +12,13 @@ class GroupMiddleware
     public function handle(Request $request, Closure $next, string ...$groups): mixed
     {
         foreach ($groups as $group) {
-            $group = str_replace($group, '-', ' ');
+            $group = str_replace('-', ' ', $group);
+
+            if (! $request->user()->inGroup($group)) {
+                return abort(config('feature-flags.middleware.status_code'));
+            }
         }
 
-        if ($request->user()->inGroup($groups)) {
-            return $next($request);
-        }
-
-        return abort(config('feature-flag.middleware.status_code'));
+        return $next($request);
     }
 }

--- a/src/Http/Middleware/API/GroupMiddleware.php
+++ b/src/Http/Middleware/API/GroupMiddleware.php
@@ -17,8 +17,8 @@ class GroupMiddleware
             if (! $request->user()->inGroup($group)) {
                 return abort(config('feature-flags.middleware.status_code'));
             }
-        }
 
-        return $next($request);
+            return $next($request);
+        }
     }
 }

--- a/src/Http/Middleware/FeatureMiddleware.php
+++ b/src/Http/Middleware/FeatureMiddleware.php
@@ -12,7 +12,7 @@ class FeatureMiddleware
     public function handle(Request $request, Closure $next, string ...$features): mixed
     {
         foreach ($features as $feature) {
-            $feature = str_replace($feature, '-', ' ');
+            $feature = str_replace('-', ' ', $feature);
 
             if (!$request->user()->hasFeature($feature)) {
                 if (config('feature-flags.middleware.mode') === 'abort') {

--- a/src/Http/Middleware/GroupMiddleware.php
+++ b/src/Http/Middleware/GroupMiddleware.php
@@ -17,14 +17,12 @@ class GroupMiddleware
             if ($request->user()->inGroup($group)) {
                 return $next($request);
             }
-
-            if (config('feature-flags.middleware.mode') === 'abort') {
-                return abort(config('feature-flags.middleware.status_code'));
-            }
-
-            return redirect(config('feature-flags.middleware.redirect_route'));
         }
 
-        return $next($request);
+        if (config('feature-flags.middleware.mode') === 'abort') {
+            return abort(config('feature-flags.middleware.status_code'));
+        }
+
+        return redirect(config('feature-flags.middleware.redirect_route'));
     }
 }

--- a/src/Http/Middleware/GroupMiddleware.php
+++ b/src/Http/Middleware/GroupMiddleware.php
@@ -12,7 +12,7 @@ class GroupMiddleware
     public function handle(Request $request, Closure $next, string ...$groups): mixed
     {
         foreach ($groups as $group) {
-            $group = str_replace($group, '-', ' ');
+            $group = str_replace('-', ' ', $group);
 
             if ($request->user()->inGroup($group)) {
                 return $next($request);

--- a/tests/Feature/ApiMiddlewareTest.php
+++ b/tests/Feature/ApiMiddlewareTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Hash;
+use JustSteveKing\Laravel\FeatureFlags\Models\Feature;
+use JustSteveKing\Laravel\FeatureFlags\Models\FeatureGroup;
+use JustSteveKing\Laravel\FeatureFlags\Tests\TestRoutes;
+use JustSteveKing\Laravel\FeatureFlags\Tests\Stubs\User;
+
+use function Pest\Laravel\actingAs;
+
+uses(TestRoutes::class);
+
+beforeEach(function (): void {
+    $this->user = User::create([
+        'name' => 'test user',
+        'email' => 'test@user.com',
+        'password' => Hash::make('password'),
+    ]);
+
+    $this->app['config']->set('feature-flags.middleware', [
+        'mode' => 'abort',
+        'redirect_route' => '/',
+        'status_code' => 404,
+    ],);
+});
+
+it('can access feature page via middleware', function (): void {
+    $feature = Feature::create([
+        'name' => 'test feature',
+    ]);
+
+    $this->user->giveFeature($feature->name);
+
+    actingAs($this->user)
+        ->get('/api/feature')
+        ->assertStatus(200);
+});
+
+it('can access feature group page via middleware', function (): void {
+    $group = FeatureGroup::create([
+        'name' => 'test feature group',
+    ]);
+
+    $this->user->joinGroup($group->name);
+
+    actingAs($this->user)
+        ->get('/api/feature-group')
+        ->assertStatus(200);
+});
+
+it('cannot access to feature page and aborts', function (): void {
+    actingAs($this->user)
+        ->get('/feature')
+        ->assertStatus(404);
+});
+
+it('cannot access to feature group page and aborts', function (): void {
+    actingAs($this->user)
+        ->get('/feature-group')
+        ->assertStatus(404);
+});

--- a/tests/Feature/ApiMiddlewareTest.php
+++ b/tests/Feature/ApiMiddlewareTest.php
@@ -31,11 +31,28 @@ it('can access feature page via middleware', function (): void {
         'name' => 'test feature',
     ]);
 
+    $feature_two = Feature::create([
+        'name' => 'test feature two',
+    ]);
+
     $this->user->giveFeature($feature->name);
+    $this->user->giveFeature($feature_two->name);
 
     actingAs($this->user)
         ->get('/api/feature')
         ->assertStatus(200);
+});
+
+it('cannot access feature page when feature flag is not attached', function (): void {
+    $feature = Feature::create([
+        'name' => 'test feature',
+    ]);
+
+    $this->user->giveFeature($feature->name);
+
+    actingAs($this->user)
+        ->get('/api/feature')
+        ->assertStatus(404);
 });
 
 it('can access feature group page via middleware', function (): void {

--- a/tests/Feature/MiddlewareTest.php
+++ b/tests/Feature/MiddlewareTest.php
@@ -31,12 +31,29 @@ it('can access feature page via middleware', function (): void {
         'name' => 'test feature',
     ]);
 
+    $feature_two = Feature::create([
+        'name' => 'test feature two',
+    ]);
+
     $this->user->giveFeature($feature->name);
+    $this->user->giveFeature($feature_two->name);
 
     actingAs($this->user)
         ->get('/feature')
         ->assertSeeText('can access feature')
         ->assertStatus(200);
+});
+
+it('cannot access feature page when feature flag is not attached', function (): void {
+    $feature = Feature::create([
+        'name' => 'test feature',
+    ]);
+
+    $this->user->giveFeature($feature->name);
+
+    actingAs($this->user)
+        ->get('/feature')
+        ->assertRedirect('/');
 });
 
 it('can access feature group page via middleware', function (): void {

--- a/tests/Feature/MiddlewareTest.php
+++ b/tests/Feature/MiddlewareTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Hash;
+use JustSteveKing\Laravel\FeatureFlags\Models\Feature;
+use JustSteveKing\Laravel\FeatureFlags\Models\FeatureGroup;
+use JustSteveKing\Laravel\FeatureFlags\Tests\TestRoutes;
+use JustSteveKing\Laravel\FeatureFlags\Tests\Stubs\User;
+
+use function Pest\Laravel\actingAs;
+
+uses(TestRoutes::class);
+
+beforeEach(function (): void {
+    $this->user = User::create([
+        'name' => 'test user',
+        'email' => 'test@user.com',
+        'password' => Hash::make('password'),
+    ]);
+
+    $this->app['config']->set('feature-flags.middleware', [
+        'mode' => 'redirect',
+        'redirect_route' => '/',
+        'status_code' => 404,
+    ],);
+});
+
+it('can access feature page via middleware', function (): void {
+    $feature = Feature::create([
+        'name' => 'test feature',
+    ]);
+
+    $this->user->giveFeature($feature->name);
+
+    actingAs($this->user)
+        ->get('/feature')
+        ->assertSeeText('can access feature')
+        ->assertStatus(200);
+});
+
+it('can access feature group page via middleware', function (): void {
+    $group = FeatureGroup::create([
+        'name' => 'test feature group',
+    ]);
+
+    $this->user->joinGroup($group->name);
+
+    actingAs($this->user)
+        ->get('/feature-group')
+        ->assertSeeText('can access feature group')
+        ->assertStatus(200);
+});
+
+it('cannot access to feature page and redirects', function (): void {
+    actingAs($this->user)
+        ->get('/feature')
+        ->assertRedirect('/');
+});
+
+it('cannot access to feature group page and redirects', function (): void {
+    actingAs($this->user)
+        ->get('/feature-group')
+        ->assertRedirect('/');
+});
+
+it('cannot access to feature page and aborts', function (): void {
+    $this->app['config']->set('feature-flags.middleware.mode', 'abort');
+
+    actingAs($this->user)
+        ->get('/feature')
+        ->assertStatus(404);
+});
+
+it('cannot access to feature group page and aborts', function (): void {
+    $this->app['config']->set('feature-flags.middleware.mode', 'abort');
+
+    actingAs($this->user)
+        ->get('/feature-group')
+        ->assertStatus(404);
+});

--- a/tests/Feature/MiddlewareTest.php
+++ b/tests/Feature/MiddlewareTest.php
@@ -58,7 +58,7 @@ it('cannot access feature page when feature flag is not attached', function (): 
 
 it('can access feature group page via middleware', function (): void {
     $group = FeatureGroup::create([
-        'name' => 'test feature group',
+        'name' => 'test feature group two',
     ]);
 
     $this->user->joinGroup($group->name);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 use JustSteveKing\Laravel\FeatureFlags\Tests\TestCase;
 
-uses(TestCase::class)->in('Unit');
+uses(TestCase::class)->in('Feature', 'Unit');

--- a/tests/TestRoutes.php
+++ b/tests/TestRoutes.php
@@ -27,22 +27,22 @@ trait TestRoutes
 
         $router->get('/feature', function (): Response {
             return response('can access feature');
-        })->middleware('feature:test-feature, test feature two');
+        })->middleware('feature:test-feature,test feature two');
 
         $router->get('/feature-group', function (): Response {
             return response('can access feature group');
-        })->middleware('feature-group:test-feature-group, test feature two');
+        })->middleware('feature-group:test-feature-group,test feature two');
 
         $router->prefix('/api')
             ->group(function (Router $router): void {
 
                 $router->get('/feature', function (): Response {
                     return response('can access feature');
-                })->middleware('api-feature:test-feature, test feature two');
+                })->middleware('api-feature:test-feature,test feature two');
 
                 $router->get('/feature-group', function (): Response {
                     return response('can access feature group');
-                })->middleware('api-feature-group:test-feature-group, test feature two');
+                })->middleware('api-feature-group:test-feature-group,test feature two');
             });
     }
 }

--- a/tests/TestRoutes.php
+++ b/tests/TestRoutes.php
@@ -31,7 +31,7 @@ trait TestRoutes
 
         $router->get('/feature-group', function (): Response {
             return response('can access feature group');
-        })->middleware('feature-group:test-feature-group,test feature two');
+        })->middleware('feature-group:test-feature-group,test feature group two');
 
         $router->prefix('/api')
             ->group(function (Router $router): void {
@@ -42,7 +42,7 @@ trait TestRoutes
 
                 $router->get('/feature-group', function (): Response {
                     return response('can access feature group');
-                })->middleware('api-feature-group:test-feature-group,test feature two');
+                })->middleware('api-feature-group:test-feature-group,test feature group two');
             });
     }
 }

--- a/tests/TestRoutes.php
+++ b/tests/TestRoutes.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustSteveKing\Laravel\FeatureFlags\Tests;
+
+use Illuminate\Http\Response;
+use Illuminate\Routing\Router;
+use JustSteveKing\Laravel\FeatureFlags\Http\Middleware\API\FeatureMiddleware as ApiFeatureMiddleware;
+use JustSteveKing\Laravel\FeatureFlags\Http\Middleware\API\GroupMiddleware as ApiGroupMiddleware;
+use JustSteveKing\Laravel\FeatureFlags\Http\Middleware\FeatureMiddleware;
+use JustSteveKing\Laravel\FeatureFlags\Http\Middleware\GroupMiddleware;
+
+trait TestRoutes
+{
+    /**
+     * @param Router $router
+     * @return void
+     */
+    protected function defineRoutes($router)
+    {
+        $router
+            ->aliasMiddleware('feature', FeatureMiddleware::class)
+            ->aliasMiddleware('feature-group', GroupMiddleware::class)
+            ->aliasMiddleware('api-feature', ApiFeatureMiddleware::class)
+            ->aliasMiddleware('api-feature-group', ApiGroupMiddleware::class);
+
+        $router->get('/feature', function (): Response {
+            return response('can access feature');
+        })->middleware('feature:test-feature, test feature two');
+
+        $router->get('/feature-group', function (): Response {
+            return response('can access feature group');
+        })->middleware('feature-group:test-feature-group, test feature two');
+
+        $router->prefix('/api', function (Router $router): void {
+
+            $router->get('/feature', function (): Response {
+                return response('can access feature');
+            })->middleware('api-feature:test-feature, test feature two');
+
+            $router->get('/feature-group', function (): Response {
+                return response('can access feature group');
+            })->middleware('api-feature-group:test-feature-group, test feature two');
+        });
+    }
+}

--- a/tests/TestRoutes.php
+++ b/tests/TestRoutes.php
@@ -33,15 +33,16 @@ trait TestRoutes
             return response('can access feature group');
         })->middleware('feature-group:test-feature-group, test feature two');
 
-        $router->prefix('/api', function (Router $router): void {
+        $router->prefix('/api')
+            ->group(function (Router $router): void {
 
-            $router->get('/feature', function (): Response {
-                return response('can access feature');
-            })->middleware('api-feature:test-feature, test feature two');
+                $router->get('/feature', function (): Response {
+                    return response('can access feature');
+                })->middleware('api-feature:test-feature, test feature two');
 
-            $router->get('/feature-group', function (): Response {
-                return response('can access feature group');
-            })->middleware('api-feature-group:test-feature-group, test feature two');
-        });
+                $router->get('/feature-group', function (): Response {
+                    return response('can access feature group');
+                })->middleware('api-feature-group:test-feature-group, test feature two');
+            });
     }
 }


### PR DESCRIPTION
This PR adds tests to confirm the middleware works correctly, which they currently don't.
This is due to the `str_replace` function call in the foreach. The returned string in the latter always returns an empty space.

This happens no matter what is passed into `str_replace`, I have confirmed this with the following [3v4l](https://3v4l.org/UG0mc).